### PR TITLE
Add simple chat assistant placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ The main objectives of Dropbox Clone are:
 - To provide seamless file synchronization across devices, ensuring users have access to their files anytime, anywhere.
 - To facilitate easy sharing and collaboration on documents and folders among users and teams.
 
+## 🧠 Document Assistant (MVP)
+
+This version introduces a simple chat interface that lets you ask questions about your uploaded documents. The backend currently returns a placeholder response. Future iterations will integrate real semantic search and AI-driven answers.
+
 ## 🔧 Technologies Used
 
 ![HTML](https://img.shields.io/badge/HTML-%23e34c26.svg?logo=html5&logoColor=white&style=for-the-badge)

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const { question } = await req.json();
+
+  // TODO: integrate real semantic search and document analysis
+  // For MVP we return a placeholder answer
+  const answer = `You asked: ${question}. (AI response placeholder)`;
+
+  return NextResponse.json({ answer });
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,0 +1,10 @@
+import Chat from "@/components/Chat";
+
+export default function ChatPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Document Assistant</h1>
+      <Chat />
+    </div>
+  );
+}

--- a/components/Chat.tsx
+++ b/components/Chat.tsx
@@ -1,0 +1,68 @@
+"use client";
+import { useState } from "react";
+
+interface Message {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export default function Chat() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMessage: Message = { role: "user", content: input };
+    setMessages((prev) => [...prev, userMessage]);
+    setInput("");
+    const res = await fetch("/api/chat", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ question: userMessage.content }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      const assistantMessage: Message = { role: "assistant", content: data.answer };
+      setMessages((prev) => [...prev, assistantMessage]);
+    } else {
+      const assistantMessage: Message = {
+        role: "assistant",
+        content: "Error getting answer.",
+      };
+      setMessages((prev) => [...prev, assistantMessage]);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full max-w-2xl mx-auto p-4 space-y-4">
+      <div className="flex-1 overflow-y-auto border rounded p-4 space-y-2">
+        {messages.map((m, idx) => (
+          <div key={idx} className={m.role === "user" ? "text-right" : "text-left"}>
+            <span
+              className={
+                m.role === "user" ? "bg-blue-500 text-white" : "bg-gray-200 text-black"
+              }
+              style={{ padding: "4px 8px", borderRadius: "4px", display: "inline-block" }}
+            >
+              {m.content}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex space-x-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && sendMessage()}
+          className="flex-1 border rounded p-2"
+          placeholder="Ask a question about your documents..."
+        />
+        <button onClick={sendMessage} className="bg-blue-500 text-white px-4 rounded">
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement simple chat component
- add chat page
- add API route for placeholder AI responses
- document new MVP chat assistant in README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848284a8db4832b92e98903f390a629